### PR TITLE
Fix: don't init loading state on some conditions

### DIFF
--- a/src/promise-btn.directive.spec.ts
+++ b/src/promise-btn.directive.spec.ts
@@ -360,6 +360,20 @@ describe('PromiseBtnDirective', () => {
         expect(promiseBtnDirective2.initLoadingState).toHaveBeenCalled();
       });
     });
+
+    it('should cancel the loading state on click when anything else than a promise is passed', () => {
+      fixture.componentInstance.testPromise = 'some string';
+      fixture.detectChanges();
+
+      buttonElement.click();
+      divElement.click();
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        expect(promiseBtnDirective1.initLoadingState).not.toHaveBeenCalled();
+        expect(promiseBtnDirective2.initLoadingState).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('cfg before runtime', () => {

--- a/src/promise-btn.directive.ts
+++ b/src/promise-btn.directive.ts
@@ -190,6 +190,11 @@ export class PromiseBtnDirective implements OnDestroy, AfterContentInit {
     // handle current button only options via click
     if (this.cfg.handleCurrentBtnOnly) {
       btnEl.addEventListener(this.cfg.CLICK_EVENT, () => {
+        // return if something else than a promise is passed
+        if (!this.promise || !this.promise.then) {
+          return;
+        }
+
         // due to some really weird reasons, we need a timeout
         // to let the model still update when a button
         // inside a form is disabled


### PR DESCRIPTION
It was possible to init loading state when anything else than a promise is passed and cfg:handleCurrentBtnOnly is true