### PR TITLE
docs(readme): Fix import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install angular2-promise-buttons -S
 
 And add it as a dependency to your main module
 ```typescript
-import {Angular2PromiseButtonModule} from 'angular2-promise-buttons/dist';
+import {Angular2PromiseButtonModule} from 'angular2-promise-buttons';
 
 @NgModule({
   imports: [


### PR DESCRIPTION
Now the import description matches in both examples. 

Importing with `/dist` throws an error with angular 9 at least. 