### PR TITLE
https://github.com/johannesjo/angular2-promise-buttons/issues/34

### DIFF
--- a/projects/angular2-promise-buttons/src/promise-btn.directive.ts
+++ b/projects/angular2-promise-buttons/src/promise-btn.directive.ts
@@ -74,16 +74,17 @@ export class PromiseBtnDirective implements OnDestroy, AfterContentInit, OnChang
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.hasOwnProperty("disabledValueOfButton")) {
-      if (this.cfg.disableBtn && typeof this.cfg.btnLoadingClass === 'string') {
+      if (this.cfg.disableBtn) {
         // When the disableBtn config is on, the disabled state/attribute is set when the loadingindicator is shown
-        // When the loading indicator is removed, the disabled state must react on the disabled value of the button
-        if (this.btnEl.classList.contains(this.cfg.btnLoadingClass)) {
-          // it is loading, so do not change the loading state
-        } else if (this.disabledValueOfButton) {
-          this.btnEl.setAttribute('disabled', 'disabled');
-        } else {
-          this.btnEl.removeAttribute('disabled');
-        }
+        // When the loading indicator is removed (the isPromiseDone = true), the disabled state must react on the disabled value of the button
+        if (this.isPromiseDone) {
+          if (this.disabledValueOfButton) {
+            this.btnEl.setAttribute('disabled', 'disabled');
+          } else {
+            this.btnEl.removeAttribute('disabled');
+          }
+
+        } // else the button is loading, so do not change the disabled loading state.
       }
     }
   }

--- a/projects/angular2-promise-buttons/src/promise-btn.directive.ts
+++ b/projects/angular2-promise-buttons/src/promise-btn.directive.ts
@@ -1,4 +1,4 @@
-import {AfterContentInit, Directive, ElementRef, HostListener, Inject, Input, OnDestroy} from '@angular/core';
+import {AfterContentInit, Directive, ElementRef, HostListener, Inject, Input, OnDestroy, OnChanges, SimpleChanges} from '@angular/core';
 import {Observable, Subscription} from 'rxjs';
 import {DEFAULT_CFG} from './default-promise-btn-config';
 import {PromiseBtnConfig} from './promise-btn-config';
@@ -8,7 +8,7 @@ import {userCfg} from './user-cfg';
   selector: '[promiseBtn]'
 })
 
-export class PromiseBtnDirective implements OnDestroy, AfterContentInit {
+export class PromiseBtnDirective implements OnDestroy, AfterContentInit, OnChanges {
   cfg: PromiseBtnConfig;
   // the timeout used for min duration display
   minDurationTimeout: number;
@@ -21,6 +21,9 @@ export class PromiseBtnDirective implements OnDestroy, AfterContentInit {
   // the promise itself or a function expression
   // NOTE: we need the type any here as we might deal with custom promises like bluebird
   promise: any;
+
+  @Input("disabled")
+  disabledValueOfButton: boolean; // this is added to fix the overriding of the disabled state by the loading indicator button. https://github.com/johannesjo/angular2-promise-buttons/issues/34
 
   private _fakePromiseResolve: () => void;
 
@@ -67,6 +70,22 @@ export class PromiseBtnDirective implements OnDestroy, AfterContentInit {
     this.prepareBtnEl(this.btnEl);
     // trigger changes once to handle initial promises
     this.checkAndInitPromiseHandler(this.btnEl);
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.hasOwnProperty("disabledValueOfButton")) {
+      if (this.cfg.disableBtn && typeof this.cfg.btnLoadingClass === 'string') {
+        // When the disableBtn config is on, the disabled state/attribute is set when the loadingindicator is shown
+        // When the loading indicator is removed, the disabled state must react on the disabled value of the button
+        if (this.btnEl.classList.contains(this.cfg.btnLoadingClass)) {
+          // it is loading, so do not change the loading state
+        } else if (this.disabledValueOfButton) {
+          this.btnEl.setAttribute('disabled', 'disabled');
+        } else {
+          this.btnEl.removeAttribute('disabled');
+        }
+      }
+    }
   }
 
   ngOnDestroy() {
@@ -152,7 +171,11 @@ export class PromiseBtnDirective implements OnDestroy, AfterContentInit {
 
   enableBtn(btnEl: HTMLElement) {
     if (this.cfg.disableBtn) {
-      btnEl.removeAttribute('disabled');
+      if (this.disabledValueOfButton) {
+        btnEl.setAttribute('disabled', String(this.disabledValueOfButton));
+      } else {
+        btnEl.removeAttribute('disabled');
+      }
     }
   }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -99,7 +99,6 @@
   </button>
 
   <button class="btn btn-raised"
-          (click)="initBooleanFor5Seconds()"
           [disabled]="customDisabled"
           [promiseBtn]="myBoolWithCustomDisabled">Work with a boolean flag, but with custom disabled flag set to true after clicking, the button should remain disabled
   </button>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -90,3 +90,17 @@
           [promiseBtn]="myBool">My Boolean Btn {{myBool}}
   </button>
 </div>
+
+<div>
+  <h2>Simple Boolean but with custom [disabled] setting </h2>
+
+  <button class="btn btn-raised"
+          (click)="myBoolWithCustomDisabled=!myBoolWithCustomDisabled">Toggle loading ({{myBoolWithCustomDisabled}})
+  </button>
+
+  <button class="btn btn-raised"
+          (click)="initBooleanFor5Seconds()"
+          [disabled]="customDisabled"
+          [promiseBtn]="myBoolWithCustomDisabled">Work with a boolean flag, but with custom disabled flag set to true after clicking, the button should remain disabled
+  </button>
+</div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -86,6 +86,8 @@ export class AppComponent {
   endlessObservable: Subscription;
   chainedObservableValue: any;
   chainedObservable: Subscription;
+  customDisabled = true;
+  myBoolWithCustomDisabled = false;
 
   constructor() {
     this.endlessInitial();
@@ -185,5 +187,9 @@ export class AppComponent {
       .then(() => {
         this.promiseIndex++;
       });
+  }
+
+  initBooleanFor5Seconds() {
+
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -189,7 +189,4 @@ export class AppComponent {
       });
   }
 
-  initBooleanFor5Seconds() {
-
-  }
 }


### PR DESCRIPTION
Try to fix the removal of custom disabled settings. [This could be usefull when working in forms, like form.invalid]

@johannesjo  a pull request for https://github.com/johannesjo/angular2-promise-buttons/issues/34

When the button is loading the button is disabled, but, with the @input of the hidden  attribute,
the state of the outside hidden is tracked.
The outside hidden state is set on the component when the promise is resolved and when the hidden input changes.

I think the function name enableButton does not cover the full details anymore, so it should be named different now. But it is public function so it cannot be changed without bumping a major version, so I left the same name.

Please take a look at it.
TravisCI seems to be okay!

Kind regards
Pieter